### PR TITLE
gitignore: fix too eager ignore rule for binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@
 # vendor/
 
 # Output binary
-exodus-rsync
+/exodus-rsync


### PR DESCRIPTION
Just 'exodus-rsync' will also ignore the *directory* of that name.